### PR TITLE
Fix initial build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 set -e
-set -x
 
 build=$1
 cache=$2
@@ -11,7 +10,7 @@ mkdir -p $build/.profile.d
 mkdir -p $cache
 
 install_backplane() {
-	echo "----> Installing Backplane Agent"
+	echo "-----> Installing Backplane Agent"
 	name=backplane-stable-linux-amd64.tgz
 	curl -s https://bin.equinox.io/c/jWahGASjoRq/$name > $cache/$name
 	tar xf $cache/$name -C $build/bin
@@ -19,7 +18,7 @@ install_backplane() {
 
 install_backplane
 
-echo "----> Writing .profile.d/backplane.sh"
+echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $build/.profile.d/backplane.sh
 BACKPLANE_LABELS="\$BACKPLANE_LABELS, heroku=true"
 \$HOME/bin/backplane connect "\$BACKPLANE_LABELS" http://127.0.0.1:\$PORT &

--- a/bin/compile
+++ b/bin/compile
@@ -8,6 +8,7 @@ cache=$2
 
 mkdir -p $build/bin
 mkdir -p $build/.profile.d
+mkdir -p $cache
 
 install_backplane() {
 	echo "----> Installing Backplane Agent"

--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,3 @@
 #!/bin/sh
-echo "-----> Backplane backend detected."
+echo "Backplane"
 exit 0


### PR DESCRIPTION
My initial deploy for a new app failed, because the cache directory did not yet exist:

```bash
$ heroku buildpacks:add https://github.com/backplaneio/backplane-heroku-buildpack
Buildpack set. Next release on another-backplane-test will use https://github.com/backplaneio/backplane-heroku-buildpack.
$ git push heroku master
Counting objects: 593, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (222/222), done.
Writing objects: 100% (593/593), 89.78 KiB | 0 bytes/s, done.
Total 593 (delta 391), reused 445 (delta 316)
remote: Compressing source files... done.
remote: Building source:
remote: 
remote: -----> -----> Backplane backend detected. app detected
remote: + build=/tmp/build_b01758a3adeb851ff88e50c6727a4499
remote: + cache=/app/tmp/cache
remote: + mkdir -p /tmp/build_b01758a3adeb851ff88e50c6727a4499/bin
remote: + mkdir -p /tmp/build_b01758a3adeb851ff88e50c6727a4499/.profile.d
remote: + install_backplane
remote: + echo ----> Installing Backplane Agent
remote: ----> Installing Backplane Agent
remote: + name=backplane-stable-linux-amd64.tgz
remote: /app/tmp/buildpacks/9ed28ff1ea30025613eaf126ec41ff2d7c056a7961d744aaf8027eb71e839af25065192b9d862c78db43d18ca90002c2878a0f343aa96953956814f18c5b976a/bin/compile: 15: /app/tmp/buildpacks/9ed28ff1ea30025613eaf126ec41ff2d7c056a7961d744aaf8027eb71e839af25065192b9d862c78db43d18ca90002c2878a0f343aa96953956814f18c5b976a/bin/compile: cannot create /app/tmp/cache/backplane-stable-linux-amd64.tgz: Directory nonexistent
remote: + curl -s https://bin.equinox.io/c/jWahGASjoRq/backplane-stable-linux-amd64.tgz
remote:  !     Push rejected, failed to compile -----> Backplane backend detected. app.
remote: 
remote:  !     Push failed
remote: Verifying deploy...
remote: 
remote: !	Push rejected to another-backplane-test.
remote: 
To https://git.heroku.com/another-backplane-test.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/another-backplane-test.git'
```

This branch fixes `bin/compile` to make deployment work 🚀

* [ensure cache directory exists](https://devcenter.heroku.com/articles/buildpack-api#caching)

    > If the build pack does intend to use a cache, it should create the `CACHE_DIR` directory if it doesn’t exist.
* clean-up log output; match normal indent style `-----> `
* revise name returned from `bin/detect` to simply **Backplane**, so it displays nicely in the Heroku dashboard