### PR TITLE
Whitelist process types

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,28 @@ The Backplane buildpack will do the following things at compile time:
 
 At runtime:
 
-* Start the Backplane agent `backplane connect` - This will get its
-	  labels from the BACKPLANE_LABELS environment variable and its
-authentication token from BACKPLANE_TOKEN.
+* Start the Backplane agent `backplane connect` - This will get its labels from the 
+`BACKPLANE_LABELS` environment variable and its authentication token from `BACKPLANE_TOKEN`.
 
 ## Use
 
+### Setup backplane routing
+
 If you haven't already created a route now is a good time to do so:
 
-	$ backplane route myendpoint.com "some=label"
+    $ backplane route myendpoint.com "some=label"
+
+### Add the backplane buildpack
 
 Add the Backplane buildpack to the list of buildpacks for your Heroku app and
 configure:
 
-	$ heroku buildpacks:add https://github.com/backplane/backplane-heroku-buildpack
-	$ heroku config:set BACKPLANE_LABELS="some=label" $(backplane generate env | grep TOKEN)
+    $ heroku buildpacks:add https://github.com/backplane/backplane-heroku-buildpack
+    $ heroku config:set BACKPLANE_LABELS="some=label" $(backplane generate env | grep TOKEN)
 
 You are now ready to deploy:
 
-	$ git push heroku master
+    $ git push heroku master
 
 > NOTE: You may now turn off inbound traffic from Heroku's router by changing
 > your process name from `web` to `www` or whatever you see fit. Each process
@@ -42,13 +45,23 @@ Test http://myendpoint.com.
 
 For more information on setting up backplane see `backplane help`.
 
+### Whitelist process types
+
+Use enviroment variable `BACKPLANE_ALLOW_PROCESS_TYPE` to whitelist process types
+which serve http traffic. If left unset, the process types 'web' and 'www' will
+be whitelisted by default.
+
+Example:
+
+    $ heroku config:set BACKPLANE_ALLOW_PROCESS_TYPE=internalweb,externalweb
+
 ## Known Issues
 
 ### Fetch Error
 
 At times Heroku may report:
 
-	Push rejected, failed to detect set buildpack https://github.com/backplane/backplane-heroku-buildpack
+  Push rejected, failed to detect set buildpack https://github.com/backplane/backplane-heroku-buildpack
 
 This happens intermittently without changes to the buildpack and "fixes itself"
 after some time due to what we believe to be issues on Heroku's end. Please

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For more information on setting up backplane see `backplane help`.
 ### Whitelist process types
 
 Use enviroment variable `BACKPLANE_PROCESS_ALLOW` to whitelist process types
-which serve http traffic. If left unset, the process type 'web' will be whitelisted 
+which serve http traffic. If left unset, the process type 'web' and 'www' will be whitelisted 
 by default.
 
 Example:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ You are now ready to deploy:
 > NOTE: You may now turn off inbound traffic from Heroku's router by changing
 > your process name from `web` to `www` or whatever you see fit. Each process
 > should still bind to `127.0.0.1:$PORT` where the backplane agent will be
-> looking for it.
+> looking for it. However, if you do change the process name, be sure to whitelist
+> it with the BACKPLANE_PROCESS_ALLOW environment variable.
 
 Test http://myendpoint.com.
 
@@ -47,13 +48,13 @@ For more information on setting up backplane see `backplane help`.
 
 ### Whitelist process types
 
-Use enviroment variable `BACKPLANE_ALLOW_PROCESS_TYPES` to whitelist process types
-which serve http traffic. If left unset, the process types 'web' and 'www' will
-be whitelisted by default.
+Use enviroment variable `BACKPLANE_PROCESS_ALLOW` to whitelist process types
+which serve http traffic. If left unset, the process type 'web' will be whitelisted 
+by default.
 
 Example:
 
-    $ heroku config:set BACKPLANE_ALLOW_PROCESS_TYPES=internalweb,externalweb
+    $ heroku config:set BACKPLANE_PROCESS_ALLOW=www,admin
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ For more information on setting up backplane see `backplane help`.
 
 ### Whitelist process types
 
-Use enviroment variable `BACKPLANE_ALLOW_PROCESS_TYPE` to whitelist process types
+Use enviroment variable `BACKPLANE_ALLOW_PROCESS_TYPES` to whitelist process types
 which serve http traffic. If left unset, the process types 'web' and 'www' will
 be whitelisted by default.
 
 Example:
 
-    $ heroku config:set BACKPLANE_ALLOW_PROCESS_TYPE=internalweb,externalweb
+    $ heroku config:set BACKPLANE_ALLOW_PROCESS_TYPES=internalweb,externalweb
 
 ## Known Issues
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,13 +20,13 @@ install_backplane() {
 
 install_backplane
 
-if [ -f $envDir/BACKPLANE_ALLOW_PROCESS_TYPES ]; then 
-  whitelist=$(cat $envDir/BACKPLANE_ALLOW_PROCESS_TYPES)
+if [ -f $envDir/BACKPLANE_PROCESS_ALLOW ]; then 
+  whitelist=$(cat $envDir/BACKPLANE_PROCESS_ALLOW)
 fi
-whitelist=${whitelist:-web,www}
-echo "-----> Backplane Agent whitelists 'web' and 'www' process types by default."
-echo "       Use enviroment variable BACKPLANE_ALLOW_PROCESS_TYPES to whitelist alternate process types."
-echo "       Example: BACKPLANE_ALLOW_PROCESS_TYPES=internal,external"
+whitelist=${whitelist:-web}
+echo "-----> Backplane Agent whitelists the 'web' process type by default."
+echo "       Use enviroment variable BACKPLANE_PROCESS_ALLOW to whitelist alternate process types."
+echo "       Example: BACKPLANE_PROCESS_ALLOW=internal,external"
 echo ""
 echo "-----> Backplane Agent whitelisted process types: $whitelist"
 echo ""
@@ -35,7 +35,7 @@ echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $buildDir/.profile.d/backplane.sh
 allowed="no"
 CURRENT_PROCESS_TYPE=\${DYNO%.*}
-IFS=", " read -r -a array <<< "\${BACKPLANE_ALLOW_PROCESS_TYPES:-web,www}"
+IFS=", " read -r -a array <<< "\${BACKPLANE_PROCESS_ALLOW:-web}"
 for element in "\${array[@]}"
 do
   if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ if [ -f $envDir/BACKPLANE_PROCESS_ALLOW ]; then
   whitelist=$(cat $envDir/BACKPLANE_PROCESS_ALLOW)
 fi
 whitelist=${whitelist:-web}
-echo "-----> Backplane Agent whitelists the 'web' process type by default."
+echo "-----> Backplane Agent whitelists the 'web' and 'www' process types by default."
 echo "       Use enviroment variable BACKPLANE_PROCESS_ALLOW to whitelist alternate process types."
 echo "       Example: BACKPLANE_PROCESS_ALLOW=internal,external"
 echo ""
@@ -35,7 +35,7 @@ echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $buildDir/.profile.d/backplane.sh
 allowed="no"
 CURRENT_PROCESS_TYPE=\${DYNO%.*}
-IFS=", " read -r -a array <<< "\${BACKPLANE_PROCESS_ALLOW:-web}"
+IFS=", " read -r -a array <<< "\${BACKPLANE_PROCESS_ALLOW:-web,www}"
 for element in "\${array[@]}"
 do
   if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -41,16 +41,21 @@ echo ""
 
 echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $buildDir/.profile.d/backplane.sh
+allowed="no"
 CURRENT_PROCESS_TYPE=\${DYNO%.*}
 IFS=", " read -r -a array <<< "$whitelist"
 for element in "\${array[@]}"
 do
   if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then
-    echo "[backplane] Starting Backplane Agent for \"$labels\""
-    \$HOME/bin/backplane connect "$labels" http://127.0.0.1:\$PORT &
-    echo "[backplane] Backplane Agent running"
-    exit 0
+    allowed="yes"
+    break
   fi
 done
-echo '[backplane] Skipping start of Backplane Agent'
+if [ "\$allowed" == "yes" ]; then
+  echo "[backplane] Starting Backplane Agent for \"$labels\""
+  \$HOME/bin/backplane connect "$labels" http://127.0.0.1:\$PORT &
+  echo "[backplane] Backplane Agent running"
+else
+  echo '[backplane] Skipping start of Backplane Agent'
+fi
 EOF

--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,9 @@ install_backplane() {
 
 install_backplane
 
-whitelist=$(cat $envDir/BACKPLANE_ALLOW_PROCESS_TYPES 2>/dev/null)
+if [ -f $envDir/BACKPLANE_ALLOW_PROCESS_TYPES ]; then 
+  whitelist=$(cat $envDir/BACKPLANE_ALLOW_PROCESS_TYPES)
+fi
 whitelist=${whitelist:-web,www}
 echo "-----> Backplane Agent whitelists 'web' and 'www' process types by default."
 echo "       Use enviroment variable BACKPLANE_ALLOW_PROCESS_TYPES to whitelist alternate process types."
@@ -29,7 +31,11 @@ echo ""
 echo "-----> Backplane Agent whitelisted process types: $whitelist"
 echo ""
 
-labels=$(cat $envDir/BACKPLANE_LABELS 2>/dev/null)
+if [ -f $envDir/BACKPLANE_LABELS ]; then 
+  labels="$(cat $envDir/BACKPLANE_LABELS), heroku=true"
+else
+  labels="heroku=true"
+fi
 echo "-----> Backplane labels: $labels"
 echo ""
 
@@ -42,9 +48,8 @@ IFS=", " read -r -a array <<< "$whitelist"
 for element in "\${array[@]}"
 do
   if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then
-    BACKPLANE_LABELS="\$BACKPLANE_LABELS, heroku=true"
-    echo "[backplane] Starting Backplane Agent for \"\$BACKPLANE_LABEL\""
-    \$HOME/bin/backplane connect "\$BACKPLANE_LABELS" http://127.0.0.1:\$PORT &
+    echo "[backplane] Starting Backplane Agent for \"$labels\""
+    \$HOME/bin/backplane connect "$labels" http://127.0.0.1:\$PORT &
     exit 0
   fi
 done

--- a/bin/compile
+++ b/bin/compile
@@ -31,19 +31,11 @@ echo ""
 echo "-----> Backplane Agent whitelisted process types: $whitelist"
 echo ""
 
-if [ -f $envDir/BACKPLANE_LABELS ]; then 
-  labels="$(cat $envDir/BACKPLANE_LABELS), heroku=true"
-else
-  labels="heroku=true"
-fi
-echo "-----> Backplane labels: $labels"
-echo ""
-
 echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $buildDir/.profile.d/backplane.sh
 allowed="no"
 CURRENT_PROCESS_TYPE=\${DYNO%.*}
-IFS=", " read -r -a array <<< "$whitelist"
+IFS=", " read -r -a array <<< "\${BACKPLANE_ALLOW_PROCESS_TYPES:-web,www}"
 for element in "\${array[@]}"
 do
   if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then
@@ -52,9 +44,8 @@ do
   fi
 done
 if [ "\$allowed" == "yes" ]; then
-  echo "[backplane] Starting Backplane Agent for \"$labels\""
-  \$HOME/bin/backplane connect "$labels" http://127.0.0.1:\$PORT &
-  echo "[backplane] Backplane Agent running"
+  echo "[backplane] Starting Backplane Agent"
+  \$HOME/bin/backplane connect "\$BACKPLANE_LABELS,heroku=true" http://127.0.0.1:\$PORT &
 else
   echo '[backplane] Skipping start of Backplane Agent'
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -20,23 +20,30 @@ install_backplane() {
 
 install_backplane
 
+whitelist=$(cat $envDir/BACKPLANE_ALLOW_PROCESS_TYPES 2>/dev/null)
+whitelist=${whitelist:-web,www}
 echo "-----> Backplane Agent whitelists 'web' and 'www' process types by default."
 echo "       Use enviroment variable BACKPLANE_ALLOW_PROCESS_TYPES to whitelist alternate process types."
 echo "       Example: BACKPLANE_ALLOW_PROCESS_TYPES=internal,external"
 echo ""
-echo "-----> Backplane Agent whitelisted process types: $(cat $envDir/BACKPLANE_ALLOW_PROCESS_TYPES)"
+echo "-----> Backplane Agent whitelisted process types: $whitelist"
 echo ""
-echo "-----> Backplane labels: $(cat $envDir/BACKPLANE_LABELS)"
+
+labels=$(cat $envDir/BACKPLANE_LABELS 2>/dev/null)
+echo "-----> Backplane labels: $labels"
 echo ""
+
 echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $buildDir/.profile.d/backplane.sh
-BACKPLANE_ALLOW_PROCESS_TYPES=\${BACKPLANE_ALLOW_PROCESS_TYPES:-web,www}
-IFS=", " read -r -a array <<< "\$BACKPLANE_ALLOW_PROCESS_TYPES"
+CURRENT_PROCESS_TYPE=\${DYNO%.*}
+echo "[backplane] Current process type: \$CURRENT_PROCESS_TYPE"
+
+IFS=", " read -r -a array <<< "$whitelist"
 for element in "\${array[@]}"
 do
   if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then
-    echo "[backplane] Starting Backplane Agent for \$BACKPLANE_LABELS"
     BACKPLANE_LABELS="\$BACKPLANE_LABELS, heroku=true"
+    echo "[backplane] Starting Backplane Agent for \"\$BACKPLANE_LABEL\""
     \$HOME/bin/backplane connect "\$BACKPLANE_LABELS" http://127.0.0.1:\$PORT &
     exit 0
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -10,16 +10,33 @@ mkdir -p $build/.profile.d
 mkdir -p $cache
 
 install_backplane() {
-	echo "-----> Installing Backplane Agent"
-	name=backplane-stable-linux-amd64.tgz
-	curl -s https://bin.equinox.io/c/jWahGASjoRq/$name > $cache/$name
-	tar xf $cache/$name -C $build/bin
+  echo "-----> Installing Backplane Agent"
+  name=backplane-stable-linux-amd64.tgz
+  curl -s https://bin.equinox.io/c/jWahGASjoRq/$name > $cache/$name
+  tar xf $cache/$name -C $build/bin
 }
 
 install_backplane
 
 echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $build/.profile.d/backplane.sh
-BACKPLANE_LABELS="\$BACKPLANE_LABELS, heroku=true"
-\$HOME/bin/backplane connect "\$BACKPLANE_LABELS" http://127.0.0.1:\$PORT &
+
+BACKPLANE_ALLOW_PROCESS_TYPE=\${BACKPLANE_ALLOW_PROCESS_TYPE:-web,www}
+echo "-----> Backplane Agent whitelists 'web' and 'www' process types by default."
+echo "       Use enviroment variable BACKPLANE_ALLOW_PROCESS_TYPE to whitelist alternate process types.";
+echo "       Example: BACKPLANE_ALLOW_PROCESS_TYPE=internal,external";
+echo "-----> Backplane Agent whitelisted process types: \$BACKPLANE_ALLOW_PROCESS_TYPE";
+
+IFS=", " read -r -a array <<< "\$BACKPLANE_ALLOW_PROCESS_TYPE"
+for element in "\${array[@]}"
+do
+  if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then
+    echo "-----> Starting Backplane Agent for \$BACKPLANE_LABELS"
+    BACKPLANE_LABELS="\$BACKPLANE_LABELS, heroku=true"
+    \$HOME/bin/backplane connect "\$BACKPLANE_LABELS" http://127.0.0.1:\$PORT &
+    exit 0
+  fi
+done
+
+echo '-----> Skipping start of Backplane Agent!'
 EOF

--- a/bin/compile
+++ b/bin/compile
@@ -42,14 +42,13 @@ echo ""
 echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $buildDir/.profile.d/backplane.sh
 CURRENT_PROCESS_TYPE=\${DYNO%.*}
-echo "[backplane] Current process type: \$CURRENT_PROCESS_TYPE"
-
 IFS=", " read -r -a array <<< "$whitelist"
 for element in "\${array[@]}"
 do
   if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then
     echo "[backplane] Starting Backplane Agent for \"$labels\""
     \$HOME/bin/backplane connect "$labels" http://127.0.0.1:\$PORT &
+    echo "[backplane] Backplane Agent running"
     exit 0
   fi
 done

--- a/bin/compile
+++ b/bin/compile
@@ -2,41 +2,44 @@
 
 set -e
 
-build=$1
-cache=$2
+buildDir=$1
+cacheDir=$2
+envDir=$3
 
-mkdir -p $build/bin
-mkdir -p $build/.profile.d
-mkdir -p $cache
+mkdir -p $buildDir/bin
+mkdir -p $buildDir/.profile.d
+mkdir -p $cacheDir
+mkdir -p $envDir
 
 install_backplane() {
   echo "-----> Installing Backplane Agent"
   name=backplane-stable-linux-amd64.tgz
-  curl -s https://bin.equinox.io/c/jWahGASjoRq/$name > $cache/$name
-  tar xf $cache/$name -C $build/bin
+  curl -s https://bin.equinox.io/c/jWahGASjoRq/$name > $cacheDir/$name
+  tar xf $cacheDir/$name -C $buildDir/bin
 }
 
 install_backplane
 
-echo "-----> Writing .profile.d/backplane.sh"
-cat <<-EOF > $build/.profile.d/backplane.sh
-
-BACKPLANE_ALLOW_PROCESS_TYPE=\${BACKPLANE_ALLOW_PROCESS_TYPE:-web,www}
 echo "-----> Backplane Agent whitelists 'web' and 'www' process types by default."
-echo "       Use enviroment variable BACKPLANE_ALLOW_PROCESS_TYPE to whitelist alternate process types.";
-echo "       Example: BACKPLANE_ALLOW_PROCESS_TYPE=internal,external";
-echo "-----> Backplane Agent whitelisted process types: \$BACKPLANE_ALLOW_PROCESS_TYPE";
-
-IFS=", " read -r -a array <<< "\$BACKPLANE_ALLOW_PROCESS_TYPE"
+echo "       Use enviroment variable BACKPLANE_ALLOW_PROCESS_TYPES to whitelist alternate process types."
+echo "       Example: BACKPLANE_ALLOW_PROCESS_TYPES=internal,external"
+echo ""
+echo "-----> Backplane Agent whitelisted process types: $(cat $envDir/BACKPLANE_ALLOW_PROCESS_TYPES)"
+echo ""
+echo "-----> Backplane labels: $(cat $envDir/BACKPLANE_LABELS)"
+echo ""
+echo "-----> Writing .profile.d/backplane.sh"
+cat <<-EOF > $buildDir/.profile.d/backplane.sh
+BACKPLANE_ALLOW_PROCESS_TYPES=\${BACKPLANE_ALLOW_PROCESS_TYPES:-web,www}
+IFS=", " read -r -a array <<< "\$BACKPLANE_ALLOW_PROCESS_TYPES"
 for element in "\${array[@]}"
 do
   if [ "\$element" == "\$CURRENT_PROCESS_TYPE" ]; then
-    echo "-----> Starting Backplane Agent for \$BACKPLANE_LABELS"
+    echo "[backplane] Starting Backplane Agent for \$BACKPLANE_LABELS"
     BACKPLANE_LABELS="\$BACKPLANE_LABELS, heroku=true"
     \$HOME/bin/backplane connect "\$BACKPLANE_LABELS" http://127.0.0.1:\$PORT &
     exit 0
   fi
 done
-
-echo '-----> Skipping start of Backplane Agent!'
+echo '[backplane] Skipping start of Backplane Agent'
 EOF


### PR DESCRIPTION
_(This is inspired by, but is the inverse of, this PR https://github.com/backplane/backplane-heroku-buildpack/pull/3)_

Use env var ~`BACKPLANE_ALLOW_PROCESS_TYPES`~ `BACKPLANE_PROCESS_ALLOW` to whitelist process types that serve http traffic. 

If left unset, the whitelist defaults to "web,www".