### PR TITLE
specify labels unique to a process type

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Test http://myendpoint.com.
 
 For more information on setting up backplane see `backplane help`.
 
+### Multiple web server process types
+
+In order to route traffic to the correct dynos you can apply unique labels to a process type
+by using the `BACKPLANE_LABELS_<proc>` environment variable. Only the backplane agents running
+on dynos for the `<proc>` process type will apply these labels. Note: the labels from
+`BACKPLANE_LABELS` will also be applied universally across all whitelisted process types.
+
+Example:
+
+    $ heroku config:set BACKPLANE_LABELS_externalweb="endpoint=external.myendpoint.com"
+
 ## Known Issues
 
 ### Fetch Error

--- a/bin/compile
+++ b/bin/compile
@@ -18,8 +18,18 @@ install_backplane() {
 
 install_backplane
 
+echo "-----> Backplane Agent sources labels from the enviroment varaible BACKPLANE_LABELS by default."
+echo "       Add unique labels for each process listed in the Procfile using BACKPLANE_LABELS_<proc>."
+echo "       Example: BACKPLANE_LABELS_web=\"endpoint=www.mydomain.com\""
+
 echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $build/.profile.d/backplane.sh
+CURRENT_PROCESS_TYPE=\${DYNO%.*}
+BACKPLANE_LABELS_proc=BACKPLANE_LABELS_\${CURRENT_PROCESS_TYPE}
+if [ -n \${!BACKPLANE_LABELS_proc+x} ]; then
+  BACKPLANE_LABELS="\$BACKPLANE_LABELS, \${!BACKPLANE_LABELS_proc}"
+fi
+
 BACKPLANE_LABELS="\$BACKPLANE_LABELS, heroku=true"
 \$HOME/bin/backplane connect "\$BACKPLANE_LABELS" http://127.0.0.1:\$PORT &
 EOF


### PR DESCRIPTION
Use env vars that have a pattern like `BACKPLANE_LABELS_<proc>` to specify unique labels for a process type. 

When using multiple process types as web servers, one typically would wish to route traffic differently between them. Since the config is shared across all process types, `BACKPLANE_LABELS` is insufficient to achieve this.

Eg:

```
backplane route www.mydomain.com "endpoint=www.mydomain.com"
backplane route admin.mydomain.com "endpoint=admin.mydomain.com"
```

Procfile:
```
web: web
admin: admin
worker: worker
```

```
BACKPLANE_LABELS_web="endpoint=www.mydomain.com"
BACKPLANE_LABELS_admin="endpoint=admin.mydomain.com"
```